### PR TITLE
Add invite functionality for wedding guests via email, SMS, or link

### DIFF
--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 
+// Only import @sendgrid/mail on the server
+let sendgridMail: typeof import("@sendgrid/mail") | null = null;
+if (typeof window === "undefined") {
+  // @ts-ignore
+  sendgridMail = require("@sendgrid/mail");
+}
+
 // In a real app, use a DB! For demo, in-memory
 const guests: Record<string, any> = {};
 
@@ -39,10 +46,38 @@ export async function POST(req: NextRequest) {
     rsvp: false, // RSVP status, default to false
   };
 
-  // Stub: Send email or SMS
+  // Actually send email using SendGrid if configured
   if (method === "email" && email) {
-    // TODO: Integrate with real email service (e.g., SendGrid)
-    console.log(`[STUB] Sent invite to ${email} with link: ${inviteLink}`);
+    const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY;
+    const SENDGRID_FROM_EMAIL = process.env.SENDGRID_FROM_EMAIL;
+    if (!SENDGRID_API_KEY || !SENDGRID_FROM_EMAIL) {
+      return NextResponse.json(
+        { error: "SendGrid is not configured. Please set SENDGRID_API_KEY and SENDGRID_FROM_EMAIL in your environment." },
+        { status: 500 }
+      );
+    }
+    try {
+      if (sendgridMail) {
+        sendgridMail.setApiKey(SENDGRID_API_KEY);
+        await sendgridMail.send({
+          to: email,
+          from: SENDGRID_FROM_EMAIL,
+          subject: "You're Invited to the Wedding!",
+          html: `
+            <p>Hi ${name},</p>
+            <p>You are invited to our wedding! Please use the link below to RSVP:</p>
+            <p><a href="${inviteLink}">${inviteLink}</a></p>
+            <p>We hope to see you there!</p>
+          `,
+        });
+      }
+    } catch (err: any) {
+      console.error("SendGrid error:", err);
+      return NextResponse.json(
+        { error: "Failed to send email invite." },
+        { status: 500 }
+      );
+    }
   } else if (method === "sms" && phone) {
     // TODO: Integrate with real SMS service (e.g., Twilio)
     console.log(`[STUB] Sent SMS to ${phone} with link: ${inviteLink}`);

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 import { query } from "@/src/db";
+import { z } from "zod";
 
 // Only import @sendgrid/mail on the server
 let sendgridMail: typeof import("@sendgrid/mail") | null = null;
@@ -14,11 +15,38 @@ function generateInviteLink(guestId: string) {
   return `https://yourdomain.com/invite/${guestId}`;
 }
 
+// Zod schema for request validation
+const inviteSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  email: z.string().email("Invalid email").optional().or(z.literal("")),
+  phone: z.string().optional().or(z.literal("")),
+  method: z.enum(["email", "sms", "link"]),
+});
+
+// (Optional) Zod schema for DB guest validation
+const guestSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  email: z.string().nullable(),
+  phone: z.string().nullable(),
+  method: z.string(),
+  invite_link: z.string(),
+  invited_at: z.date().or(z.string()),
+  status: z.string(),
+  rsvp: z.boolean(),
+});
+
 // GET: Return list of all guests
 export async function GET() {
   try {
     const res = await query("SELECT * FROM guests ORDER BY invited_at DESC");
-    return NextResponse.json({ guests: res.rows });
+    // Optionally validate each guest row
+    const guests = res.rows.map((guest: any) => {
+      // Accept both string/timestamp for invited_at for compatibility
+      guestSchema.parse(guest); // Throws if invalid
+      return guest;
+    });
+    return NextResponse.json({ guests });
   } catch (err) {
     console.error("DB error:", err);
     return NextResponse.json({ error: "Database error" }, { status: 500 });
@@ -26,10 +54,33 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const { name, email, phone, method } = await req.json();
+  let body: any;
+  try {
+    body = await req.json();
+  } catch (e) {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
 
-  if (!name || (!email && !phone)) {
-    return NextResponse.json({ error: "Missing guest info" }, { status: 400 });
+  // Validate input using Zod
+  const parsed = inviteSchema.safeParse(body);
+  if (!parsed.success) {
+    const message =
+      parsed.error.errors.map(e => `${e.path[0]}: ${e.message}`).join(", ") ||
+      "Invalid input";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+  const { name, email, phone, method } = parsed.data;
+
+  // Require at least email or phone for email/sms, allow neither for link
+  if (
+    (method === "email" && !email) ||
+    (method === "sms" && !phone) ||
+    (!email && !phone && method !== "link")
+  ) {
+    return NextResponse.json(
+      { error: "Email or phone is required for this invite method." },
+      { status: 400 }
+    );
   }
 
   // Generate unique ID for the guest
@@ -41,7 +92,7 @@ export async function POST(req: NextRequest) {
     await query(
       `INSERT INTO guests (id, name, email, phone, method, invite_link, invited_at, status, rsvp)
        VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7, $8)`,
-      [guestId, name, email, phone, method, inviteLink, "invited", false]
+      [guestId, name, email || null, phone || null, method, inviteLink, "invited", false]
     );
   } catch (err) {
     console.error("DB insert error:", err);

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+
+// In a real app, use a DB! For demo, in-memory
+const guests: Record&lt;string, any&gt; = {};
+
+function generateInviteLink(guestId: string) {
+  // In production, use your real domain
+  return `https://yourdomain.com/invite/${guestId}`;
+}
+
+export async function POST(req: NextRequest) {
+  const { name, email, phone, method } = await req.json();
+
+  if (!name || (!email && !phone)) {
+    return NextResponse.json({ error: "Missing guest info" }, { status: 400 });
+  }
+
+  // Generate unique ID for the guest
+  const guestId = crypto.randomUUID();
+  const inviteLink = generateInviteLink(guestId);
+
+  // Store guest (simulate DB)
+  guests[guestId] = {
+    id: guestId,
+    name,
+    email,
+    phone,
+    method,
+    inviteLink,
+    invitedAt: new Date().toISOString(),
+    status: "invited",
+  };
+
+  // Stub: Send email or SMS
+  if (method === "email" && email) {
+    // TODO: Integrate with real email service (e.g., SendGrid)
+    console.log(`[STUB] Sent invite to ${email} with link: ${inviteLink}`);
+  } else if (method === "sms" && phone) {
+    // TODO: Integrate with real SMS service (e.g., Twilio)
+    console.log(`[STUB] Sent SMS to ${phone} with link: ${inviteLink}`);
+  }
+
+  // Return the invite link so it can be copied/shared
+  return NextResponse.json({
+    success: true,
+    guestId,
+    inviteLink,
+    method,
+  });
+}

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -2,11 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 
 // In a real app, use a DB! For demo, in-memory
-const guests: Record&lt;string, any&gt; = {};
+const guests: Record<string, any> = {};
 
 function generateInviteLink(guestId: string) {
   // In production, use your real domain
   return `https://yourdomain.com/invite/${guestId}`;
+}
+
+// GET: Return list of all guests
+export async function GET() {
+  // Return all guests as array
+  return NextResponse.json({ guests: Object.values(guests) });
 }
 
 export async function POST(req: NextRequest) {
@@ -30,6 +36,7 @@ export async function POST(req: NextRequest) {
     inviteLink,
     invitedAt: new Date().toISOString(),
     status: "invited",
+    rsvp: false, // RSVP status, default to false
   };
 
   // Stub: Send email or SMS

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
+import { query } from "@/src/db";
 
 // Only import @sendgrid/mail on the server
 let sendgridMail: typeof import("@sendgrid/mail") | null = null;
@@ -8,9 +9,6 @@ if (typeof window === "undefined") {
   sendgridMail = require("@sendgrid/mail");
 }
 
-// In a real app, use a DB! For demo, in-memory
-const guests: Record<string, any> = {};
-
 function generateInviteLink(guestId: string) {
   // In production, use your real domain
   return `https://yourdomain.com/invite/${guestId}`;
@@ -18,8 +16,13 @@ function generateInviteLink(guestId: string) {
 
 // GET: Return list of all guests
 export async function GET() {
-  // Return all guests as array
-  return NextResponse.json({ guests: Object.values(guests) });
+  try {
+    const res = await query("SELECT * FROM guests ORDER BY invited_at DESC");
+    return NextResponse.json({ guests: res.rows });
+  } catch (err) {
+    console.error("DB error:", err);
+    return NextResponse.json({ error: "Database error" }, { status: 500 });
+  }
 }
 
 export async function POST(req: NextRequest) {
@@ -33,18 +36,17 @@ export async function POST(req: NextRequest) {
   const guestId = crypto.randomUUID();
   const inviteLink = generateInviteLink(guestId);
 
-  // Store guest (simulate DB)
-  guests[guestId] = {
-    id: guestId,
-    name,
-    email,
-    phone,
-    method,
-    inviteLink,
-    invitedAt: new Date().toISOString(),
-    status: "invited",
-    rsvp: false, // RSVP status, default to false
-  };
+  // Insert guest into database
+  try {
+    await query(
+      `INSERT INTO guests (id, name, email, phone, method, invite_link, invited_at, status, rsvp)
+       VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7, $8)`,
+      [guestId, name, email, phone, method, inviteLink, "invited", false]
+    );
+  } catch (err) {
+    console.error("DB insert error:", err);
+    return NextResponse.json({ error: "Database insert error" }, { status: 500 });
+  }
 
   // Actually send email using SendGrid if configured
   if (method === "email" && email) {

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -79,8 +79,33 @@ export async function POST(req: NextRequest) {
       );
     }
   } else if (method === "sms" && phone) {
-    // TODO: Integrate with real SMS service (e.g., Twilio)
-    console.log(`[STUB] Sent SMS to ${phone} with link: ${inviteLink}`);
+    // Twilio integration
+    const TWILIO_ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID;
+    const TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN;
+    const TWILIO_FROM_PHONE = process.env.TWILIO_FROM_PHONE;
+    if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN || !TWILIO_FROM_PHONE) {
+      return NextResponse.json(
+        { error: "Twilio is not configured. Please set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_FROM_PHONE in your environment." },
+        { status: 500 }
+      );
+    }
+    try {
+      // Only require twilio on the server
+      // @ts-ignore
+      const twilio = require("twilio")(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+      await twilio.messages.create({
+        to: phone,
+        from: TWILIO_FROM_PHONE,
+        body:
+          `Hi ${name}, you are invited to our wedding! RSVP here: ${inviteLink}`
+      });
+    } catch (err: any) {
+      console.error("Twilio error:", err);
+      return NextResponse.json(
+        { error: "Failed to send SMS invite." },
+        { status: 500 }
+      );
+    }
   }
 
   // Return the invite link so it can be copied/shared

--- a/src/app/invite/page.tsx
+++ b/src/app/invite/page.tsx
@@ -1,5 +1,17 @@
 "use client";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+
+type Guest = {
+  id: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  method: string;
+  inviteLink: string;
+  invitedAt: string;
+  status: string;
+  rsvp: boolean;
+};
 
 export default function InvitePage() {
   const [name, setName] = useState("");
@@ -10,6 +22,28 @@ export default function InvitePage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
+
+  const [guests, setGuests] = useState<Guest[]>([]);
+  const [loadingGuests, setLoadingGuests] = useState(false);
+
+  // Fetch all invited guests
+  const fetchGuests = async () => {
+    setLoadingGuests(true);
+    try {
+      const res = await fetch("/api/invite");
+      const data = await res.json();
+      if (res.ok && data.guests) {
+        setGuests(data.guests);
+      }
+    } catch (err) {
+      // ignore error for now
+    }
+    setLoadingGuests(false);
+  };
+
+  useEffect(() => {
+    fetchGuests();
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -29,6 +63,8 @@ export default function InvitePage() {
       } else {
         setInviteLink(data.inviteLink);
         setSuccess(true);
+        // Refresh guest list
+        fetchGuests();
       }
     } catch (err) {
       setError("Network error.");
@@ -37,7 +73,7 @@ export default function InvitePage() {
   };
 
   return (
-    <div style={{ maxWidth: 400, margin: "2rem auto", padding: 24, border: "1px solid #ddd", borderRadius: 8 }}>
+    <div style={{ maxWidth: 500, margin: "2rem auto", padding: 24, border: "1px solid #ddd", borderRadius: 8 }}>
       <h2>Invite a Wedding Guest</h2>
       <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         <label>
@@ -88,6 +124,46 @@ export default function InvitePage() {
             </button>
           </div>
         </div>
+      )}
+
+      <hr style={{ margin: "2rem 0" }} />
+
+      <h3>Guest List</h3>
+      {loadingGuests ? (
+        <div>Loading guests...</div>
+      ) : guests.length === 0 ? (
+        <div>No guests have been invited yet.</div>
+      ) : (
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr style={{ background: "#f2f2f2" }}>
+              <th style={{ padding: 6, border: "1px solid #ddd" }}>Name</th>
+              <th style={{ padding: 6, border: "1px solid #ddd" }}>Contact</th>
+              <th style={{ padding: 6, border: "1px solid #ddd" }}>Method</th>
+              <th style={{ padding: 6, border: "1px solid #ddd" }}>Invited At</th>
+              <th style={{ padding: 6, border: "1px solid #ddd" }}>RSVP</th>
+            </tr>
+          </thead>
+          <tbody>
+            {guests.map(g => (
+              <tr key={g.id}>
+                <td style={{ padding: 6, border: "1px solid #ddd" }}>{g.name}</td>
+                <td style={{ padding: 6, border: "1px solid #ddd" }}>
+                  {g.email || g.phone || "N/A"}
+                </td>
+                <td style={{ padding: 6, border: "1px solid #ddd" }}>{g.method}</td>
+                <td style={{ padding: 6, border: "1px solid #ddd" }}>{new Date(g.invitedAt).toLocaleString()}</td>
+                <td style={{ padding: 6, border: "1px solid #ddd" }}>
+                  {g.rsvp ? (
+                    <span style={{ color: "green" }}>Yes</span>
+                  ) : (
+                    <span style={{ color: "gray" }}>No</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
     </div>
   );

--- a/src/app/invite/page.tsx
+++ b/src/app/invite/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+import React, { useState } from "react";
+
+export default function InvitePage() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [method, setMethod] = useState("email");
+  const [inviteLink, setInviteLink] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+    setSuccess(false);
+    setInviteLink("");
+    try {
+      const res = await fetch("/api/invite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email, phone, method }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Failed to send invite.");
+      } else {
+        setInviteLink(data.inviteLink);
+        setSuccess(true);
+      }
+    } catch (err) {
+      setError("Network error.");
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div style={{ maxWidth: 400, margin: "2rem auto", padding: 24, border: "1px solid #ddd", borderRadius: 8 }}>
+      <h2>Invite a Wedding Guest</h2>
+      <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <label>
+          Name:
+          <input type="text" required value={name} onChange={e => setName(e.target.value)} />
+        </label>
+        <label>
+          Email:
+          <input type="email" value={email} onChange={e => setEmail(e.target.value)} disabled={method === "sms" || method === "link"} />
+        </label>
+        <label>
+          Phone:
+          <input type="tel" value={phone} onChange={e => setPhone(e.target.value)} disabled={method === "email" || method === "link"} />
+        </label>
+        <label>
+          Method:
+          <select value={method} onChange={e => setMethod(e.target.value)}>
+            <option value="email">Email</option>
+            <option value="sms">Text (SMS)</option>
+            <option value="link">Personal Link</option>
+          </select>
+        </label>
+        <button type="submit" disabled={loading}>
+          {loading ? "Sending..." : "Send Invite"}
+        </button>
+      </form>
+      {error && <div style={{ color: "#b00", marginTop: 12 }}>{error}</div>}
+      {success && (
+        <div style={{ marginTop: 16, background: "#f7f7f7", padding: 12, borderRadius: 6 }}>
+          <strong>Invitation Created!</strong>
+          <div>
+            Personal Link:{" "}
+            <input
+              type="text"
+              readOnly
+              style={{ width: "100%" }}
+              value={inviteLink}
+              onFocus={e => e.target.select()}
+            />
+            <button
+              style={{ marginTop: 8 }}
+              onClick={() => {
+                navigator.clipboard.writeText(inviteLink);
+              }}
+              type="button"
+            >
+              Copy Link
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,10 @@
+import { Pool } from "pg";
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export async function query(text: string, params?: any[]) {
+  const res = await pool.query(text, params);
+  return res;
+}


### PR DESCRIPTION
This pull request introduces a new API endpoint for inviting wedding guests. The endpoint allows for sending invitations via email, SMS, or generating a personal invite link. 

### Changes Made:
- Added a new POST route in `src/app/api/invite/route.ts` that handles guest invitations.
- The route accepts guest details (name, email, phone) and the preferred method of invitation.
- It generates a unique invite link for each guest and simulates sending an email or SMS (with stubs for future integration).
- The guest information is stored in an in-memory object for demonstration purposes.

### How it solves the issue:
This implementation allows users to invite guests through their preferred communication method, enhancing the flexibility and user experience for wedding planning.

---

> This pull request was co-created with Cosine Genie

Original Task: [wedding-creator/325wisqzpyze](https://cosine.sh/kw0z2npi0zjh/wedding-creator/task/325wisqzpyze)
Author: Peter McArthur
